### PR TITLE
Textfield input validation

### DIFF
--- a/frontend/src/pages/components/CreateChat.jsx
+++ b/frontend/src/pages/components/CreateChat.jsx
@@ -16,13 +16,17 @@ function CreateChat(props) {
     // const handleClose = () => {
     //     visible ? setVisible(false) : setVisible(true);
     // }
+    const MAX_CHATNAME_LENGTH = 512;
     const {onClose, selectedValue, open} = props;
     // const {open} = props;
     const [users, setUsers] = useState([]);
     const [chatName, setChatName] = useState("");
     const [chatMembers, setChatMembers] = useState([]);
-
-    const dummyUsers = ["adam", "brandon", "caleb", "donovan", "ethan", "francis"];
+    const [isChatNameValid, setIsChatNameValid] = useState(true);
+    const checkChatName = (text) => {
+        return !!text && !/[^a-zA-Z0-9 ():;@#$+,.-]/.test(text) && text.length <= MAX_CHATNAME_LENGTH;
+    }
+    // const dummyUsers = ["adam", "brandon", "caleb", "donovan", "ethan", "francis"];
 
     
     useEffect(() => {
@@ -55,6 +59,9 @@ function CreateChat(props) {
     }
 
     const handleSubmit = (value) => {
+        if (!isChatNameValid) {
+            return;
+        }
         const headers = new Headers();
         headers.set('Content-Type', 'application/json');
         headers.set('x-access-token', sessionStorage.getItem('token'));
@@ -79,7 +86,10 @@ function CreateChat(props) {
     }
 
     const handleChatName = (event) => {
-        setChatName(event.target.value);
+        setIsChatNameValid(checkChatName(event.target.value));
+        if (isChatNameValid) {
+            setChatName(event.target.value);
+        }
         // console.log("set chat name to "+ event.target.value);
     }
     // a
@@ -104,7 +114,9 @@ function CreateChat(props) {
             <DialogContent>
                 <TextField
                     label='Chat Name'
+                    error={!isChatNameValid}
                     onChange={handleChatName}
+                    helperText={isChatNameValid ? "" : "Invalid chat name."}
                     required
                     sx={{width: 300}}
                 />

--- a/frontend/src/pages/newaccount.js
+++ b/frontend/src/pages/newaccount.js
@@ -4,19 +4,42 @@ import { Button, Alert, AlertTitle, AppBar, Toolbar, Typography, TextField, Icon
 import useRouter from 'next/router';
 
 const Register = () => {
+  const MAX_USERNAME_LENGTH = 30;
+  const MAX_PASSWORD_LENGTH = 50;
   const router = useRouter;
   // conditionally display error if login credentials were invalid
   const [showError, setShowError] = React.useState(false);
+  const [isUsernameValid, setIsUsernameValid] = React.useState(true);
+  const [isPasswordValid, setIsPasswordValid] = React.useState(true);
+
+  // true if username is valid, false if not
+  const checkUsername = (text) => {
+    return !!text && !/[^a-zA-Z0-9]/.test(text) && text.length <= MAX_USERNAME_LENGTH;
+  }
+
+  const checkPassword = (text) => {
+    return !!text && text.length <= MAX_PASSWORD_LENGTH;
+  }
+
   let user = {username: '', password: ''}
-  const handleInputChange = (event) => {
-    const {value, name} = event.target;
-    user[name] = value;
+  const handleUsernameChange = (event) => {
+    user.username = event.target.value;
+    setIsUsernameValid(checkUsername(user.username));
+  };
+
+  const handlePasswordChange = (event) => {
+    user.password = event.target.value;
+    setIsPasswordValid(checkPassword(user.password));
   };
 
   const onSubmit = (event) => {
     event.preventDefault();
     const username = user.username;
     const password = user.password;
+
+    if (!isUsernameValid || !isPasswordValid) {
+      return;
+    }
     // checks with db that user exists
     fetch('http://localhost:5000/user', {
       headers: {
@@ -61,21 +84,25 @@ const Register = () => {
         <div className={styles.login_box}>
         <Box sx={{my: '10%', display: 'flex', justifyContent: 'center', flexDirection: 'column'}}>
           <TextField
+            error={!isUsernameValid}
             id='outlined-search'
             title='username'
             label='username'
             name='username'
-            onChange={handleInputChange}
+            onChange={handleUsernameChange}
+            helperText={isUsernameValid ? "" : "Invalid username."}
             required
             sx={{my: '2%', width: '300px'}}
           />
           <TextField
+            error={!isPasswordValid}
             id='outlined-search'
             title='password'
             label='password'
             name='password'
             type='password'
-            onChange={handleInputChange}
+            onChange={handlePasswordChange}
+            helperText={isPasswordValid ? "" : "Invalid password."}
             required
             sx={{my: '3%', width: '300px'}}
           />


### PR DESCRIPTION
Check username and password on `/newaccount`, and check chat name on `/chatpage`

- `newaccount`: username must be alphanumeric and less than 30 characters, password must be less than 50 characters
- `chatpage`: chat name can have certain symbols but not dangerous ones such as `'`, `"`, and `*`.

Validation is intentionally omitted from `/login` since logging in with invalid credentials will result in a failure response anyways, but I could add the same logic here too if needed.