### PR TITLE
Cosmetic improvements chatpage

### DIFF
--- a/frontend/src/pages/components/ConversationPanel.jsx
+++ b/frontend/src/pages/components/ConversationPanel.jsx
@@ -9,7 +9,6 @@ function ConversationPanel({setConversationMessages}) {
     // const mockData = {"Adam": [{'username': 'Adam', 'message': 'I\'m Adam'}],
     //                   "     ": [{'username': 'Bob', 'message': 'I\'m Bob'}],
     //                   "Claire": [{'username': 'Claire', 'message': 'I\'m Claire'}]};
-    const [currentChat, setCurrentChat] = React.useState("");
     const [messages, setMessages] = React.useState([]);
     // Endpoint for <id> chat
     // Endpoint for all chat name
@@ -63,7 +62,6 @@ function ConversationPanel({setConversationMessages}) {
         // setUsers(value);
         // fetch endpoint for <id> chat history
         //setMessages(mockData[value]);
-        setCurrentChat(value);
         sessionStorage.currentChat = value['id'];
         console.log("handling autocomplete");
         

--- a/frontend/src/pages/components/CreateChat.jsx
+++ b/frontend/src/pages/components/CreateChat.jsx
@@ -40,8 +40,10 @@ function CreateChat(props) {
             }
         ).then((response) => {
             if (response.users) {
-                setUsers(response.users);
-                return response.users;
+                let otherUsers = response.users.filter(uname => uname != sessionStorage.Username);
+                console.log(otherUsers);
+                setUsers(otherUsers);
+                return otherUsers;
             }
         }).catch((err) => {
             console.error(`error from ${err}`);

--- a/frontend/src/pages/components/Message.jsx
+++ b/frontend/src/pages/components/Message.jsx
@@ -17,11 +17,11 @@ export class Message extends React.Component {
     }
     render() {
         return (
-        <div ref={this.messageRef} className={styles.message}>
-          <div className={styles.username}>
+        <div ref={this.messageRef}>
+          <div className={styles.conversation_username}>
             {this.props.message['data']['username']}
           </div>
-          <div>
+          <div className={styles.conversation_message}>
             {this.props.message['data']['message']}
           </div>
           <br/>

--- a/frontend/src/pages/home.js
+++ b/frontend/src/pages/home.js
@@ -14,7 +14,7 @@ function Home() {
   const router = useRouter;
 
   useEffect(() => {
-    router.push(localStorage.getItem("Username") ? '/chatpage' : '/newaccount');
+    router.push(localStorage.getItem("Username") ? '/chatpage' : '/login');
   });
 };
 

--- a/frontend/src/styles.module.css
+++ b/frontend/src/styles.module.css
@@ -122,13 +122,30 @@
     width: 100%;
   }
 
-  .message {
+  .conversation_message {
     position: relative;
     bottom: 0;
+    display: inline-block;
+    width: auto;
+    background-color: #d0d0d0;
+    color: #333;
+    padding: 0.7rem 1.1rem;
+    line-height: 1.25rem;
+    border-radius: 1.4rem;
+    font-weight: 400;
+    font-size: 1.25rem;
+    font-family: Arial, Helvetica, sans-serif;
+    word-break: normal;
+    overflow-wrap: anywhere;
   }
 
-  .username {
-    font-weight: bold;
+  .conversation_username {
+    padding: 0.3rem;
+    color: #575757;
+    font-weight: 400;
+    font-size: 1.25rem;
+    font-family: Arial, Helvetica, sans-serif;
+    /*font-weight: bold;*/
   }
 
   .text_field {


### PR DESCRIPTION
Various UI/UX changes

Currently includes the following improvements:

1. messages now look like this
![image](https://user-images.githubusercontent.com/31453551/202820773-ed98df1b-3a20-4941-9d1c-f249cf5b0f26.png)
2. create chat dropdown no longer includes your own username (you will automatically be included in your own chatroom)
3. homepage now redirects to `/login` when the user is not logged in, rather than `/newaccount`