### PR TITLE
Replace dropdown chat selector with sidebar

### DIFF
--- a/frontend/src/pages/components/ConversationPanel.jsx
+++ b/frontend/src/pages/components/ConversationPanel.jsx
@@ -5,13 +5,11 @@ import configData from '../../config.json';
 
 function ConversationPanel({setConversationMessages}) {
     const [chats, setChats] = React.useState([]);
-    // const mockData = {"Adam": [{'username': 'Adam', 'message': 'I\'m Adam'}],
-    //                   "     ": [{'username': 'Bob', 'message': 'I\'m Bob'}],
-    //                   "Claire": [{'username': 'Claire', 'message': 'I\'m Claire'}]};
-    const [messages, setMessages] = React.useState([]);
+    const [selectedChat, setSelectedChat] = React.useState("");
 
     const fetchConversationHistory = (chat) => {
         sessionStorage.currentChat = chat['id'];
+        setSelectedChat(chat['id']);
 
         // Get message history from backend, then save it in state
         let headers = new Headers();
@@ -95,7 +93,9 @@ function ConversationPanel({setConversationMessages}) {
             {
                 chats.map((chat) => {
                     return (
-                        <ListItem button divider onClick={() => fetchConversationHistory(chat)}>
+                        <ListItem button divider
+                         onClick={() => fetchConversationHistory(chat)}
+                         selected={chat.id == selectedChat}>
                             <ListItemText primary={chat.label} />
                         </ListItem>
                     )

--- a/frontend/src/pages/components/ConversationPanel.jsx
+++ b/frontend/src/pages/components/ConversationPanel.jsx
@@ -10,25 +10,16 @@ function ConversationPanel({setConversationMessages}) {
     //                   "Claire": [{'username': 'Claire', 'message': 'I\'m Claire'}]};
     const [messages, setMessages] = React.useState([]);
 
-    const handleAutocomplete = (event, value) => {
-        // setUsers(value);
-        // fetch endpoint for <id> chat history
-        //setMessages(mockData[value]);
-        sessionStorage.currentChat = value['id'];
-        console.log("handling autocomplete");
-        
-        //console.log(event);
-        console.log(value);
-        console.log("value");
+    const fetchConversationHistory = (chat) => {
+        sessionStorage.currentChat = chat['id'];
 
-        // call fetch chatid history api here instead of the above setmessages, using value["id"]
-
+        // Get message history from backend, then save it in state
         let headers = new Headers();
         headers.set('Content-Type', 'application/json');
         headers.set('Accept', 'application/json');
         headers.set('x-access-token', sessionStorage.token);
         
-        fetch(configData.HOSTNAME + ':5000/chat/' + value["id"], {
+        fetch(configData.HOSTNAME + ':5000/chat/' + chat['id'], {
         headers: headers,
         method: 'GET',
         }).then((response) => 
@@ -80,8 +71,10 @@ function ConversationPanel({setConversationMessages}) {
                     //console.log("chats:");
                     //console.log(chats);
                 }
+
+                // Set chat to general chat if nothing is currently selected
                 if (!sessionStorage.currentChat) {
-                    handleAutocomplete(null, displayChatroom[0]);
+                    fetchConversationHistory(displayChatroom[0]);
                 }
 
                 return response["chatrooms"];
@@ -89,78 +82,7 @@ function ConversationPanel({setConversationMessages}) {
                 console.log("couldn't fetch chatrooms");
             }
         });
-        //let chatroomList = response['chatrooms'];
-
-        //let chatroomList = accurateMockData["chatrooms"];
     });
-
-    const handleAutocomplete = (event, value) => {
-        // setUsers(value);
-        // fetch endpoint for <id> chat history
-        //setMessages(mockData[value]);
-        sessionStorage.currentChat = value['id'];
-        console.log("handling autocomplete");
-        
-        //console.log(event);
-        console.log(value);
-        console.log("value");
-
-        // call fetch chatid history api here instead of the above setmessages, using value["id"]
-
-        let headers = new Headers();
-        headers.set('Content-Type', 'application/json');
-        headers.set('Accept', 'application/json');
-        headers.set('x-access-token', sessionStorage.token);
-        
-        fetch(configData.HOSTNAME + ":5000/chat/" + value["id"], {
-        headers: headers,
-        method: 'GET',
-        }).then((response) => 
-        {
-            //console.log(response.text());
-            return response.json();
-        })
-        .then((response) => {
-            console.log("response text:");
-            console.log(response);
-            if (response) {
-                setConversationMessages(response['messages']); // probably need to edit this, i dont know the shape of the data
-                return response;
-            } else {
-                console.log("error fetching message history");
-            }
-        });
-    }
-
-    const handleChatSelect = (chat) => {
-        sessionStorage.currentChat = chat['id'];
-
-        // call fetch chatid history api here instead of the above setmessages, using value["id"]
-
-        let headers = new Headers();
-        headers.set('Content-Type', 'application/json');
-        headers.set('Accept', 'application/json');
-        headers.set('x-access-token', sessionStorage.token);
-        
-        fetch(configData.HOSTNAME + ":5000/chat/" + chat["id"], {
-        headers: headers,
-        method: 'GET',
-        }).then((response) => 
-        {
-            //console.log(response.text());
-            return response.json();
-        })
-        .then((response) => {
-            console.log("response text:");
-            console.log(response);
-            if (response) {
-                setConversationMessages(response['messages']); // probably need to edit this, i dont know the shape of the data
-                return response;
-            } else {
-                console.log("error fetching message history");
-            }
-        });
-    }
 
     return(
         <Box sx={{
@@ -169,18 +91,11 @@ function ConversationPanel({setConversationMessages}) {
             '& > *': { 
                 m: 1,}, 
         }}>
-            <Autocomplete
-                options={chats}
-                fullWidth
-                onChange={handleAutocomplete}
-                renderInput={(params) => <TextField {...params} variant="filled" label="Chats"/>}
-            />
         <List>
             {
                 chats.map((chat) => {
-                    console.log(chat)
                     return (
-                        <ListItem button divider onClick={() => handleChatSelect(chat)}>
+                        <ListItem button divider onClick={() => fetchConversationHistory(chat)}>
                             <ListItemText primary={chat.label} />
                         </ListItem>
                     )

--- a/frontend/src/pages/components/ConversationPanel.jsx
+++ b/frontend/src/pages/components/ConversationPanel.jsx
@@ -1,9 +1,7 @@
-import { Box, ButtonGroup, Button, Typography, Autocomplete, TextField } from "@mui/material";
-import React, {useEffect,useMemo} from "react";
-import styles from '../../styles.module.css';
-import createMuiTheme from "@mui/material/styles";
-import { useState } from 'react';
-import configData from "../../config.json";
+import { Box, Autocomplete, TextField, 
+    ListItemText, List, ListItem, Divider } from '@mui/material';
+import React, { useEffect } from 'react';
+import configData from '../../config.json';
 
 function ConversationPanel({setConversationMessages}) {
     const [chats, setChats] = React.useState([]);
@@ -96,6 +94,74 @@ function ConversationPanel({setConversationMessages}) {
         //let chatroomList = accurateMockData["chatrooms"];
     });
 
+    const handleAutocomplete = (event, value) => {
+        // setUsers(value);
+        // fetch endpoint for <id> chat history
+        //setMessages(mockData[value]);
+        sessionStorage.currentChat = value['id'];
+        console.log("handling autocomplete");
+        
+        //console.log(event);
+        console.log(value);
+        console.log("value");
+
+        // call fetch chatid history api here instead of the above setmessages, using value["id"]
+
+        let headers = new Headers();
+        headers.set('Content-Type', 'application/json');
+        headers.set('Accept', 'application/json');
+        headers.set('x-access-token', sessionStorage.token);
+        
+        fetch(configData.HOSTNAME + ":5000/chat/" + value["id"], {
+        headers: headers,
+        method: 'GET',
+        }).then((response) => 
+        {
+            //console.log(response.text());
+            return response.json();
+        })
+        .then((response) => {
+            console.log("response text:");
+            console.log(response);
+            if (response) {
+                setConversationMessages(response['messages']); // probably need to edit this, i dont know the shape of the data
+                return response;
+            } else {
+                console.log("error fetching message history");
+            }
+        });
+    }
+
+    const handleChatSelect = (chat) => {
+        sessionStorage.currentChat = chat['id'];
+
+        // call fetch chatid history api here instead of the above setmessages, using value["id"]
+
+        let headers = new Headers();
+        headers.set('Content-Type', 'application/json');
+        headers.set('Accept', 'application/json');
+        headers.set('x-access-token', sessionStorage.token);
+        
+        fetch(configData.HOSTNAME + ":5000/chat/" + chat["id"], {
+        headers: headers,
+        method: 'GET',
+        }).then((response) => 
+        {
+            //console.log(response.text());
+            return response.json();
+        })
+        .then((response) => {
+            console.log("response text:");
+            console.log(response);
+            if (response) {
+                setConversationMessages(response['messages']); // probably need to edit this, i dont know the shape of the data
+                return response;
+            } else {
+                console.log("error fetching message history");
+            }
+        });
+    }
+
     return(
         <Box sx={{
             flexDirection: 'column',
@@ -104,58 +170,25 @@ function ConversationPanel({setConversationMessages}) {
                 m: 1,}, 
         }}>
             <Autocomplete
-                    options={chats}
-                    fullWidth
-                    onChange={handleAutocomplete}
-                    renderInput={(params) => <TextField {...params} variant="filled" label="Chats"/>}
-                />
-            {/* <ButtonGroup
-            orientation="vertical"
-            aria-label="vertical outlined button group"
-            >
-                <Typography sx={{textAlign: "center", width: "125%", marginBottom: "15px"}}>select a conversation</Typography>
-                <Button sx={{width: "125%"}} key="General">General</Button>
-                {users.map((user) =>
-                    <Button sx={{width: "125%"}} key={user}>{user}</Button>
-                )}
-            </ButtonGroup> */}
+                options={chats}
+                fullWidth
+                onChange={handleAutocomplete}
+                renderInput={(params) => <TextField {...params} variant="filled" label="Chats"/>}
+            />
+        <List>
+            {
+                chats.map((chat) => {
+                    console.log(chat)
+                    return (
+                        <ListItem button divider onClick={() => handleChatSelect(chat)}>
+                            <ListItemText primary={chat.label} />
+                        </ListItem>
+                    )
+                })
+            }
+        </List>
         </Box>
     )
 }
-
-// export class ConversationPanel extends React.Component {
-//     constructor() {
-//         const [users, setUsers] = React.useState(["Adam", "Bob", "Claire"]);
-
-//         super();
-//         // this.conversations = [
-//         //     <Button disabled key="0">Select a Conversation:</Button>,
-//         //     <Button key="1">Adam</Button>,
-//         //     <Button key="2">Bob</Button>,
-//         //     <Button key="3">Claire</Button>,
-//         //   ];
-//         this.conversations = users.map((user) =>
-//             <Button>{user}</Button>
-//         )
-//     }
-
-//     render() {
-//         return(
-//             <Box sx={{
-//                 display: 'flex',
-//                 '& > *': { 
-//                     m: 1,}, 
-//             }}>
-//                 <ButtonGroup
-//                 orientation="vertical"
-//                 aria-label="vertical outlined button group"
-//                 >
-//                     seelc a user
-//                     {this.conversations}
-//                 </ButtonGroup>
-//             </Box>
-//         )
-//     }
-// };
 
 export default ConversationPanel;


### PR DESCRIPTION
Includes Zach's sidebar branch and some code cleanup by me, as well as MUI List selection logic

Entire chatpage interface now looks like this:
![image](https://user-images.githubusercontent.com/31453551/203180731-e9a439eb-b845-4361-a6d1-9db91dfff1f2.png)
Notice the general chat is highlighted in the sidebar since it is selected.